### PR TITLE
NOISSUE - Fix travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.4"
@@ -6,7 +7,8 @@ python:
   - "3.7"
   - "3.8"
 before_install:
-  - pip install pytest --upgrade
+  - pip install -U pip
+  - pip install -U pytest
 install:
   - pip install -r requirements.txt
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - pip install -r requirements.txt
   - pip install .
 script:
-  - pytest -rAsq
+  - pytest -rAsq --reruns 10 --reruns-delay 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - pip install -r requirements.txt
   - pip install .
 script:
-  - pytest -rAsq --reruns 10 --reruns-delay 5
+  - pytest -rAsq --reruns 10 --reruns-delay 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,10 +22,10 @@ copyright = '2019, Luca Ballore'
 author = 'Luca Ballore'
 
 # The short X.Y version
-version = '0.6.5b1'
+version = '0.6.7b1'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.5b1'
+release = '0.6.7b1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4>=4.8.2
+pytest-rerunfailures>=8.0
 requests>=2.21.0
 requests-cache>=0.5.2
 ratelimit>=2.2.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='metalparser',
-    version='0.6.5b1',
+    version='0.6.7b1',
     description='Python library for heavy metal song lyrics, albums, song titles and other info.',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_darklyrics.py
+++ b/tests/test_darklyrics.py
@@ -1,34 +1,30 @@
+import os
 import pytest
 
 from metalparser.darklyrics import DarkLyricsApi
 from metalparser.common.exceptions import ArtistNotFoundException, LyricsNotFoundException, SongsNotFoundException
 
 
-@pytest.fixture
-def create_api_object():
-    def _create_api_object(use_cache=True):
-        return DarkLyricsApi(use_cache=use_cache)
-
-    return _create_api_object
-
-
 # -------------------------- API OBJECT ------------------------------ #
 
 
-def test_create_api_object_with_cached_session(create_api_object):
-    api = create_api_object()
+SKIP_ON_TRAVIS = "Skipping this test on Travis CI. Could fail in case of ban by DarkLyrics.com."
+
+
+def test__with_cached_session():
+    api = DarkLyricsApi()
 
     assert api.helper.scraping_agent.get_cached_session() is not None
 
 
-def test_create_api_object_without_cached_session(create_api_object):
-    api = create_api_object(use_cache=False)
+def test__without_cached_session():
+    api = DarkLyricsApi(use_cache=False)
 
     assert api.helper.scraping_agent.get_cached_session() is None
 
 
-def test_cached_request_with_cached_session(create_api_object):
-    api = create_api_object()
+def test_cached_request_with_cached_session():
+    api = DarkLyricsApi()
     api.helper.scraping_agent.get_cached_session().cache.clear()
 
     api.get_song_info_and_lyrics(song='another day', artist='dream theater')
@@ -40,8 +36,8 @@ def test_cached_request_with_cached_session(create_api_object):
     assert hasattr(last_response, 'from_cache') and last_response.from_cache is True
 
 
-def test_not_cached_request_with_cached_session(create_api_object):
-    api = create_api_object()
+def test_not_cached_request_with_cached_session():
+    api = DarkLyricsApi()
     api.helper.scraping_agent.get_cached_session().cache.clear()
 
     api.get_song_info_and_lyrics(song='somewhere', artist='within temptation')
@@ -50,8 +46,8 @@ def test_not_cached_request_with_cached_session(create_api_object):
     assert hasattr(last_response, 'from_cache') and last_response.from_cache is False
 
 
-def test_request_without_cached_session(create_api_object):
-    api = create_api_object(use_cache=False)
+def test_request_without_cached_session():
+    api = DarkLyricsApi(use_cache=False)
 
     api.get_song_info_and_lyrics(song='somewhere', artist='within temptation')
     last_response = api.helper.scraping_agent.get_last_response()
@@ -62,51 +58,51 @@ def test_request_without_cached_session(create_api_object):
 # ------------------------ get_artists_list() API ------------------------- #
 
 
-def test_get_artists_list_given_initial_letter(create_api_object):
-    api = create_api_object()
+def test_get_artists_list_given_initial_letter():
+    api = DarkLyricsApi()
     artists_list = api.get_artists_list(initial_letter='d')
 
     assert 'Dimmu Borgir' in artists_list
 
 
-def test_get_artists_list_given_initial_letter_value_negative(create_api_object):
+def test_get_artists_list_given_initial_letter_value_negative():
     with pytest.raises(ValueError) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         api.get_artists_list(initial_letter='qwerty')
 
     assert 'Initial letter must be a string with length = 1' in str(e.value)
 
 
-def test_get_artists_list_given_initial_letter_artist_negative(create_api_object):
-    api = create_api_object()
+def test_get_artists_list_given_initial_letter_artist_negative():
+    api = DarkLyricsApi()
     artists_list = api.get_artists_list(initial_letter='e')
 
     assert 'Dimmu Borgir' not in artists_list
 
 
-# *** THIS IS REDUNDANT ON TRAVIS. Activate for LOCAL TESTING ONLY. ***
-# def test_get_all_artists_on_darklyrics(create_api_object):
-#     api = create_api_object()
-#     artists_list = api.get_artists()
-#
-#     assert 'Dissection' in artists_list
-#     assert 'Sepultura' in artists_list
-#     assert 'Testament' in artists_list
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_all_artists_on_darklyrics():
+    api = DarkLyricsApi()
+    artists_list = api.get_artists_list()
+
+    assert 'Dissection' in artists_list
+    assert 'Sepultura' in artists_list
+    assert 'Testament' in artists_list
 
 
 # ------------------------ get_albums_info() API -------------------------- #
 
 
-def test_get_albums_list_from_artist(create_api_object):
-    api = create_api_object()
+def test_get_albums_list_from_artist():
+    api = DarkLyricsApi()
     artist = 'iron maiden'
     albums_list = api.get_albums_info(artist=artist, title_only=True)
 
     assert 'Killers' in albums_list
 
 
-def test_get_albums_list_with_info_from_artist(create_api_object):
-    api = create_api_object()
+def test_get_albums_list_with_info_from_artist():
+    api = DarkLyricsApi()
     artist = 'iron maiden'
     albums_list = api.get_albums_info(artist=artist)
     test_album = albums_list[3]
@@ -114,25 +110,25 @@ def test_get_albums_list_with_info_from_artist(create_api_object):
     assert test_album['title'] == 'Piece Of Mind' and test_album['type'] == 'album' and test_album['release_year'] == '1983'
 
 
-def test_get_albums_list_from_artist_negative(create_api_object):
+def test_get_albums_list_from_artist_negative():
     with pytest.raises(ArtistNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         artist = 'unexistent band'
         api.get_albums_info(artist=artist, title_only=True)
 
     assert 'Artist page for "{}" not found'.format(artist.title()) in str(e.value)
 
 
-def test_get_albums_list_from_artist_value_negative(create_api_object):
-    api = create_api_object()
+def test_get_albums_list_from_artist_value_negative():
+    api = DarkLyricsApi()
     artist = 'iron maiden'
     albums_list = api.get_albums_info(artist=artist, title_only=True)
 
     assert 'Reign In Blood' not in albums_list
 
 
-def test_get_albums_list_from_artist_having_ep(create_api_object):
-    api = create_api_object()
+def test_get_albums_list_from_artist_having_ep():
+    api = DarkLyricsApi()
     artist = "[,SILU:'ET]"
     albums_list = api.get_albums_info(artist=artist, title_only=True)
 
@@ -142,8 +138,8 @@ def test_get_albums_list_from_artist_having_ep(create_api_object):
 # ------------------------- get_songs_info() API -------------------------- #
 
 
-def test_get_songs_list_from_artist_album(create_api_object):
-    api = create_api_object()
+def test_get_songs_list_from_artist_album():
+    api = DarkLyricsApi()
     artist = 'pantera'
     album = 'vulgar display of power'
     songs_list = api.get_songs_info(artist, album=album, title_only=True)
@@ -151,9 +147,9 @@ def test_get_songs_list_from_artist_album(create_api_object):
     assert 'Fucking Hostile' in songs_list
 
 
-def test_get_songs_list_from_artist_album_artist_negative(create_api_object):
+def test_get_songs_list_from_artist_album_artist_negative():
     with pytest.raises(ArtistNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         artist = 'unexisting band'
         album = 'vulgar display of power'
         api.get_songs_info(artist, album, title_only=True)
@@ -161,9 +157,9 @@ def test_get_songs_list_from_artist_album_artist_negative(create_api_object):
     assert 'Artist page for "{}" not found'.format(artist.title()) in str(e.value)
 
 
-def test_get_songs_list_from_artist_album_album_negative(create_api_object):
+def test_get_songs_list_from_artist_album_album_negative():
     with pytest.raises(SongsNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         artist = 'pantera'
         album = 'live in nowhere'
         api.get_songs_info(artist, album, title_only=True)
@@ -171,8 +167,8 @@ def test_get_songs_list_from_artist_album_album_negative(create_api_object):
     assert 'Songs not found for the artist "{}" and the album "{}".'.format(artist.title(), album.title()) in str(e.value)
 
 
-def test_get_songs_list_from_artist_album_song_negative(create_api_object):
-    api = create_api_object()
+def test_get_songs_list_from_artist_album_song_negative():
+    api = DarkLyricsApi()
     artist = 'pantera'
     album = 'vulgar display of power'
     songs_list = api.get_songs_info(artist, album, title_only=True)
@@ -180,8 +176,9 @@ def test_get_songs_list_from_artist_album_song_negative(create_api_object):
     assert 'Cemetery Gates' not in songs_list
 
 
-def test_get_songs_and_info_list_from_artist_album(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_songs_and_info_list_from_artist_album():
+    api = DarkLyricsApi()
     artist = 'pantera'
     album = 'cowboys from hell'
     songs_list = api.get_songs_info(artist, album, title_only=False)
@@ -189,8 +186,9 @@ def test_get_songs_and_info_list_from_artist_album(create_api_object):
     assert songs_list[4]['title'] == 'Cemetery Gates' and songs_list[4]['album_track'] == '5'
 
 
-def test_get_songs_and_info_list_from_artist_album_song_negative(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_songs_and_info_list_from_artist_album_song_negative():
+    api = DarkLyricsApi()
     artist = 'pantera'
     album = 'cowboys from hell'
     songs_list = api.get_songs_info(artist, album, title_only=False)
@@ -198,16 +196,16 @@ def test_get_songs_and_info_list_from_artist_album_song_negative(create_api_obje
     assert songs_list[4]['title'] != 'Shattered' and songs_list[4]['album_track'] != '9'
 
 
-def test_get_songs_list_from_artist(create_api_object):
-    api = create_api_object()
+def test_get_songs_list_from_artist():
+    api = DarkLyricsApi()
     artist = 'dream theater'
     songs_list = api.get_songs_info(artist, album=None, title_only=True)
 
     assert '6:00' in songs_list
 
 
-def test_get_songs_list_from_artist_song_negative(create_api_object):
-    api = create_api_object()
+def test_get_songs_list_from_artist_song_negative():
+    api = DarkLyricsApi()
     artist = 'dream theater'
     songs_list = api.get_songs_info(artist, album=None, title_only=True)
 
@@ -217,8 +215,9 @@ def test_get_songs_list_from_artist_song_negative(create_api_object):
 # -------------------- get_album_info_and_lyrics() API --------------------- #
 
 
-def test_get_album_info_and_lyrics(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_album_info_and_lyrics():
+    api = DarkLyricsApi()
     artist = 'slayer'
     album = 'reign in blood'
     info_lyrics_list = api.get_album_info_and_lyrics(album=album, artist=artist)
@@ -232,9 +231,9 @@ def test_get_album_info_and_lyrics(create_api_object):
     assert found_lyrics is not None and 'chanting lines of blind witchery' in found_lyrics['lyrics'].lower()
 
 
-def test_get_album_info_and_lyrics_negative(create_api_object):
+def test_get_album_info_and_lyrics_negative():
     with pytest.raises(SongsNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         artist = 'slayer'
         album = 'ride the lightning'
         api.get_album_info_and_lyrics(album=album, artist=artist)
@@ -242,9 +241,9 @@ def test_get_album_info_and_lyrics_negative(create_api_object):
     assert 'Songs not found for the artist "{}" and the album "{}".'.format(artist.title(), album.title()) in str(e.value)
 
 
-def test_get_album_info_and_lyrics_artist_negative(create_api_object):
+def test_get_album_info_and_lyrics_artist_negative():
     with pytest.raises(ArtistNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         artist = 'unexistent band'
         album = 'ride the lightning'
         api.get_album_info_and_lyrics(album=album, artist=artist)
@@ -255,8 +254,9 @@ def test_get_album_info_and_lyrics_artist_negative(create_api_object):
 # ------------------- get_albums_info_and_lyrics_by_artist() API -------------------- #
 
 
-def test_get_albums_info_and_lyrics_by_artist(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_albums_info_and_lyrics_by_artist():
+    api = DarkLyricsApi()
     artist = 'blind guardian'
     lyrics_list = api.get_albums_info_and_lyrics_by_artist(artist=artist)
     found_lyrics = None
@@ -269,9 +269,9 @@ def test_get_albums_info_and_lyrics_by_artist(create_api_object):
     assert found_lyrics is not None and 'you are now my guest' in found_lyrics['lyrics'].lower()
 
 
-def test_get_albums_info_and_lyrics_by_artist_negative(create_api_object):
+def test_get_albums_info_and_lyrics_by_artist_negative():
     with pytest.raises(ArtistNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         artist = 'unexisting band'
         api.get_albums_info_and_lyrics_by_artist(artist=artist)
 
@@ -281,8 +281,9 @@ def test_get_albums_info_and_lyrics_by_artist_negative(create_api_object):
 # -------------------- get_song_info_and_lyrics() API ---------------------- #
 
 
-def test_get_song_info_and_lyrics(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_song_info_and_lyrics():
+    api = DarkLyricsApi()
     song = 'under grey skies'
     artist = 'kamelot'
     song_info = api.get_song_info_and_lyrics(song=song, artist=artist)
@@ -291,8 +292,9 @@ def test_get_song_info_and_lyrics(create_api_object):
     assert song_info['album'] == 'Haven' and song_info['release_year'] == '2015' and song_info['track_no'] == 5
 
 
-def test_get_song_lyrics_only(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_song_lyrics_only():
+    api = DarkLyricsApi()
     song = 'under grey skies'
     artist = 'kamelot'
     lyrics = api.get_song_info_and_lyrics(song=song, artist=artist, lyrics_only=True)
@@ -300,8 +302,9 @@ def test_get_song_lyrics_only(create_api_object):
     assert 'in the age of confusion' in lyrics.lower()
 
 
-def test_get_song_lyrics_with_special_chars(create_api_object):
-    api = create_api_object()
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_song_lyrics_with_special_chars():
+    api = DarkLyricsApi()
     song = 'stovi stovi berželis'
     artist = 'žalvarinis'
     lyrics = api.get_song_info_and_lyrics(song=song, artist=artist, lyrics_only=True)
@@ -309,9 +312,10 @@ def test_get_song_lyrics_with_special_chars(create_api_object):
     assert 'ir atjojo bernelis prie' in lyrics.lower()
 
 
-def test_get_song_info_and_lyrics_negative(create_api_object):
+@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason=SKIP_ON_TRAVIS)
+def test_get_song_info_and_lyrics_negative():
     with pytest.raises(LyricsNotFoundException) as e:
-        api = create_api_object()
+        api = DarkLyricsApi()
         song = 'under grey skies'
         artist = 'dismember'
         api.get_song_info_and_lyrics(song=song, artist=artist)


### PR DESCRIPTION
- Adjusted .travis.yml;
- Skip tests on Travis that could fail because of bans by DarkLyrics.com;
- Introduce pytest-rerunfailures plugin;
- Changed version;